### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ util = { package = "webrtc-util", version = "0.5.3", default-features = false, f
 rtp = "0.6.5"
 rtcp = "0.6.5"
 srtp = { package = "webrtc-srtp", version = "0.8.9" }
-tokio = { version = "1.15.0", features = ["sync", "time"] }
-async-trait = "0.1.52"
-bytes = "1.1.0"
-thiserror = "1.0.30"
-rand = "0.8.4"
+tokio = { version = "1.19", features = ["sync", "time"] }
+async-trait = "0.1.56"
+bytes = "1"
+thiserror = "1.0"
+rand = "0.8.5"
 waitgroup = "0.1.2"
-log = "0.4.14"
+log = "0.4"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/interceptor"
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["marshal"] }
+util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["marshal"] }
 rtp = "0.6.5"
 rtcp = "0.6.5"
 srtp = { package = "webrtc-srtp", version = "0.8.9" }

--- a/src/mock/mock_builder.rs
+++ b/src/mock/mock_builder.rs
@@ -2,24 +2,21 @@ use crate::error::Result;
 use crate::{Interceptor, InterceptorBuilder};
 use std::sync::Arc;
 
+pub type MockBuilderResult = Result<Arc<dyn Interceptor + Send + Sync>>;
+
 /// MockBuilder is a mock Builder for testing.
 pub struct MockBuilder {
-    pub build:
-        Box<dyn (Fn(&str) -> Result<Arc<dyn Interceptor + Send + Sync>>) + Send + Sync + 'static>,
+    pub build: Box<dyn (Fn(&str) -> MockBuilderResult) + Send + Sync + 'static>,
 }
 
 impl MockBuilder {
-    pub fn new<
-        F: (Fn(&str) -> Result<Arc<dyn Interceptor + Send + Sync>>) + Send + Sync + 'static,
-    >(
-        f: F,
-    ) -> Self {
+    pub fn new<F: (Fn(&str) -> MockBuilderResult) + Send + Sync + 'static>(f: F) -> Self {
         MockBuilder { build: Box::new(f) }
     }
 }
 
 impl InterceptorBuilder for MockBuilder {
-    fn build(&self, id: &str) -> Result<Arc<dyn Interceptor + Send + Sync>> {
+    fn build(&self, id: &str) -> MockBuilderResult {
         (self.build)(id)
     }
 }

--- a/src/report/receiver/receiver_stream.rs
+++ b/src/report/receiver/receiver_stream.rs
@@ -52,7 +52,7 @@ impl ReceiverStreamInternal {
             self.set_received(pkt.header.sequence_number);
 
             let diff = pkt.header.sequence_number as i32 - self.last_seq_num as i32;
-            if diff > 0 || diff < -0x0FFF {
+            if !(-0x0FFF..=0).contains(&diff) {
                 // overflow
                 if diff < -0x0FFF {
                     self.seq_num_cycles += 1;


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions