### PR TITLE
Add RTP stats interceptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/interceptor"
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["marshal"] }
+util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["marshal", "sync"] }
 rtp = "0.6.5"
 rtcp = "0.6.5"
 srtp = { package = "webrtc-srtp", version = "0.8.9" }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -15,6 +15,10 @@ impl Chain {
     pub fn new(interceptors: Vec<Arc<dyn Interceptor + Send + Sync>>) -> Self {
         Chain { interceptors }
     }
+
+    pub fn add(&mut self, icpr: Arc<dyn Interceptor + Send + Sync>) {
+        self.interceptors.push(icpr);
+    }
 }
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod nack;
 pub mod noop;
 pub mod registry;
 pub mod report;
+pub mod stats;
 pub mod stream_info;
 pub mod stream_reader;
 pub mod twcc;

--- a/src/mock/mock_stream.rs
+++ b/src/mock/mock_stream.rs
@@ -194,6 +194,22 @@ impl MockStream {
         rtcp_out_modified_rx.recv().await
     }
 
+    /// Returns the last rtcp packet bacth that was written, modified by the interceptor.
+    ///
+    /// NB: This method discards all other previously recoreded packet batches.
+    pub async fn last_written_rtcp(
+        &self,
+    ) -> Option<Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>> {
+        let mut last = None;
+        let mut rtcp_out_modified_rx = self.rtcp_out_modified_rx.lock().await;
+
+        while let Ok(v) = rtcp_out_modified_rx.try_recv() {
+            last = Some(v);
+        }
+
+        last
+    }
+
     /// written_rtp returns a channel containing rtp packets written, modified by the interceptor
     pub async fn written_rtp(&self) -> Option<rtp::packet::Packet> {
         let mut rtp_out_modified_rx = self.rtp_out_modified_rx.lock().await;

--- a/src/report/receiver/receiver_test.rs
+++ b/src/report/receiver/receiver_test.rs
@@ -630,7 +630,7 @@ async fn test_receiver_interceptor_jitter() -> Result<()> {
     };
 
     let icpr: Arc<dyn Interceptor + Send + Sync> = ReceiverReport::builder()
-        .with_interval(Duration::from_millis(50))
+        .with_interval(Duration::from_millis(25))
         .with_now_fn(time_gen)
         .build("")?;
 
@@ -669,7 +669,10 @@ async fn test_receiver_interceptor_jitter() -> Result<()> {
         })
         .await;
 
-    let pkts = stream.written_rtcp().await.unwrap();
+    // Wait at least 50 ms to ensure a report is generated
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let pkts = stream.last_written_rtcp().await.unwrap();
     assert_eq!(pkts.len(), 1);
     if let Some(rr) = pkts[0]
         .as_any()

--- a/src/stats/interceptor.rs
+++ b/src/stats/interceptor.rs
@@ -1,0 +1,302 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use super::{RTPStats, RTPStatsReader};
+use async_trait::async_trait;
+use util::sync::Mutex;
+use util::{MarshalSize, Unmarshal};
+
+use crate::error::Result;
+use crate::stream_info::StreamInfo;
+use crate::{Attributes, Interceptor, RTCPReader, RTCPWriter, RTPReader, RTPWriter};
+
+#[derive(Debug)]
+pub struct StatsInterceptor {
+    recv_streams: Mutex<HashMap<u32, Arc<RTPReadRecorder>>>,
+    send_streams: Mutex<HashMap<u32, Arc<RTPWriteRecorder>>>,
+    id: String,
+}
+
+impl StatsInterceptor {
+    pub fn new(id: String) -> Self {
+        Self {
+            id,
+            recv_streams: Default::default(),
+            send_streams: Default::default(),
+        }
+    }
+
+    pub fn recv_stats_reader(&self, ssrc: u32) -> Option<RTPStatsReader> {
+        self.recv_stats_readers([ssrc].iter().copied())
+            .into_iter()
+            .next()
+    }
+
+    pub fn recv_stats_readers(&self, ssrcs: impl Iterator<Item = u32>) -> Vec<RTPStatsReader> {
+        let lock = self.recv_streams.lock();
+
+        ssrcs
+            .filter_map(|ssrc| lock.get(&ssrc).map(|r| r.reader()))
+            .collect()
+    }
+
+    pub fn send_stats_reader(&self, ssrc: u32) -> Option<RTPStatsReader> {
+        self.send_stats_readers([ssrc].iter().copied())
+            .into_iter()
+            .next()
+    }
+
+    pub fn send_stats_readers(&self, ssrcs: impl Iterator<Item = u32>) -> Vec<RTPStatsReader> {
+        let lock = self.send_streams.lock();
+
+        ssrcs
+            .filter_map(|ssrc| lock.get(&ssrc).map(|r| r.reader()))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Interceptor for StatsInterceptor {
+    /// bind_remote_stream lets you modify any incoming RTP packets. It is called once for per RemoteStream. The returned method
+    /// will be called once per rtp packet.
+    async fn bind_remote_stream(
+        &self,
+        info: &StreamInfo,
+        reader: Arc<dyn RTPReader + Send + Sync>,
+    ) -> Arc<dyn RTPReader + Send + Sync> {
+        let mut lock = self.recv_streams.lock();
+
+        let e = lock
+            .entry(info.ssrc)
+            .or_insert_with(|| Arc::new(RTPReadRecorder::new(reader)));
+
+        e.clone()
+    }
+
+    /// unbind_remote_stream is called when the Stream is removed. It can be used to clean up any data related to that track.
+    async fn unbind_remote_stream(&self, info: &StreamInfo) {
+        let mut lock = self.recv_streams.lock();
+
+        lock.remove(&info.ssrc);
+    }
+
+    /// bind_local_stream lets you modify any outgoing RTP packets. It is called once for per LocalStream. The returned method
+    /// will be called once per rtp packet.
+    async fn bind_local_stream(
+        &self,
+        info: &StreamInfo,
+        writer: Arc<dyn RTPWriter + Send + Sync>,
+    ) -> Arc<dyn RTPWriter + Send + Sync> {
+        let mut lock = self.send_streams.lock();
+
+        let e = lock
+            .entry(info.ssrc)
+            .or_insert_with(|| Arc::new(RTPWriteRecorder::new(writer)));
+
+        e.clone()
+    }
+
+    /// unbind_local_stream is called when the Stream is removed. It can be used to clean up any data related to that track.
+    async fn unbind_local_stream(&self, info: &StreamInfo) {
+        let mut lock = self.send_streams.lock();
+
+        lock.remove(&info.ssrc);
+    }
+
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// bind_rtcp_writer lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
+    /// will be called once per packet batch.
+    async fn bind_rtcp_writer(
+        &self,
+        writer: Arc<dyn RTCPWriter + Send + Sync>,
+    ) -> Arc<dyn RTCPWriter + Send + Sync> {
+        // NOP
+        writer
+    }
+
+    /// bind_rtcp_reader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
+    /// change in the future. The returned method will be called once per packet batch.
+    async fn bind_rtcp_reader(
+        &self,
+        reader: Arc<dyn RTCPReader + Send + Sync>,
+    ) -> Arc<dyn RTCPReader + Send + Sync> {
+        reader
+    }
+}
+
+pub struct RTPReadRecorder {
+    rtp_reader: Arc<dyn RTPReader + Send + Sync>,
+    stats: RTPStats,
+}
+
+impl RTPReadRecorder {
+    fn new(rtp_reader: Arc<dyn RTPReader + Send + Sync>) -> Self {
+        Self {
+            rtp_reader,
+            stats: Default::default(),
+        }
+    }
+
+    fn reader(&self) -> RTPStatsReader {
+        self.stats.reader()
+    }
+}
+
+#[async_trait]
+impl RTPReader for RTPReadRecorder {
+    async fn read(&self, buf: &mut [u8], attributes: &Attributes) -> Result<(usize, Attributes)> {
+        let (bytes_read, attributes) = self.rtp_reader.read(buf, attributes).await?;
+        // TODO: This parsing happens redundantly in several interceptors, would be good if we
+        // could not do this.
+        let mut b = &buf[..bytes_read];
+        let packet = rtp::packet::Packet::unmarshal(&mut b)?;
+
+        self.stats.update(
+            (bytes_read - packet.payload.len()) as u64,
+            packet.payload.len() as u64,
+            1,
+        );
+
+        Ok((bytes_read, attributes))
+    }
+}
+
+impl fmt::Debug for RTPReadRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RTPReadRecorder")
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
+pub struct RTPWriteRecorder {
+    rtp_writer: Arc<dyn RTPWriter + Send + Sync>,
+    stats: RTPStats,
+}
+
+impl RTPWriteRecorder {
+    fn new(rtp_writer: Arc<dyn RTPWriter + Send + Sync>) -> Self {
+        Self {
+            rtp_writer,
+            stats: Default::default(),
+        }
+    }
+
+    fn reader(&self) -> RTPStatsReader {
+        self.stats.reader()
+    }
+}
+
+#[async_trait]
+impl RTPWriter for RTPWriteRecorder {
+    /// write a rtp packet
+    async fn write(&self, pkt: &rtp::packet::Packet, attributes: &Attributes) -> Result<usize> {
+        let n = self.rtp_writer.write(pkt, attributes).await?;
+
+        self.stats.update(
+            pkt.header.marshal_size() as u64,
+            pkt.payload.len() as u64,
+            1,
+        );
+
+        Ok(n)
+    }
+}
+
+impl fmt::Debug for RTPWriteRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RTPWriteRecorder")
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+
+    use std::sync::Arc;
+
+    use crate::error::Result;
+    use crate::mock::mock_stream::MockStream;
+    use crate::stream_info::StreamInfo;
+
+    use super::StatsInterceptor;
+
+    #[tokio::test]
+    async fn test_stats_interceptor() -> Result<()> {
+        let icpr: Arc<_> = Arc::new(StatsInterceptor::new("Hello".to_owned()));
+
+        let recv_stream = MockStream::new(
+            &StreamInfo {
+                ssrc: 123456,
+                ..Default::default()
+            },
+            icpr.clone(),
+        )
+        .await;
+
+        let send_stream = MockStream::new(
+            &StreamInfo {
+                ssrc: 234567,
+                ..Default::default()
+            },
+            icpr.clone(),
+        )
+        .await;
+
+        let recv_reader = icpr
+            .recv_stats_reader(123456)
+            .expect("After binding recv_stats_reader should return Some");
+
+        let send_reader = icpr
+            .send_stats_reader(234567)
+            .expect("After binding send_stats_reader should return Some");
+
+        let _ = recv_stream
+            .receive_rtp(rtp::packet::Packet {
+                header: rtp::header::Header {
+                    ..Default::default()
+                },
+                payload: Bytes::from_static(b"\xde\xad\xbe\xef"),
+            })
+            .await;
+
+        let _ = recv_stream
+            .read_rtp()
+            .await
+            .expect("After calling receive_rtp read_rtp should return Some")?;
+
+        assert_eq!(recv_reader.packets(), 1);
+        assert_eq!(recv_reader.header_bytes(), 12);
+        assert_eq!(recv_reader.payload_bytes(), 4);
+
+        let _ = send_stream
+            .write_rtp(&rtp::packet::Packet {
+                header: rtp::header::Header {
+                    ..Default::default()
+                },
+                payload: Bytes::from_static(b"\xde\xad\xbe\xef\xde\xad\xbe\xef"),
+            })
+            .await;
+
+        let _ = send_stream
+            .write_rtp(&rtp::packet::Packet {
+                header: rtp::header::Header {
+                    ..Default::default()
+                },
+                payload: Bytes::from_static(&[0x13, 0x37]),
+            })
+            .await;
+
+        assert_eq!(send_reader.packets(), 2);
+        assert_eq!(send_reader.header_bytes(), 24);
+        assert_eq!(send_reader.payload_bytes(), 10);
+
+        Ok(())
+    }
+}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,0 +1,127 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+mod interceptor;
+
+pub use self::interceptor::StatsInterceptor;
+
+pub fn make_stats_interceptor(id: &str) -> Arc<StatsInterceptor> {
+    Arc::new(StatsInterceptor::new(id.to_owned()))
+}
+
+#[derive(Debug, Default)]
+/// Records stats about a given RTP stream.
+pub struct RTPStats {
+    /// Packets sent or received
+    packets: Arc<AtomicU64>,
+
+    /// Payload bytes sent or received
+    payload_bytes: Arc<AtomicU64>,
+
+    /// Header bytes sent or received
+    header_bytes: Arc<AtomicU64>,
+
+    /// A wall clock timestamp for when the last packet was sent or recieved encoded as milliseconds since
+    /// [`SystemTime::UNIX_EPOCH`].
+    last_packet_timestamp: Arc<AtomicU64>,
+}
+
+impl RTPStats {
+    pub fn update(&self, header_bytes: u64, payload_bytes: u64, packets: u64) {
+        let now = SystemTime::now();
+
+        self.header_bytes.fetch_add(header_bytes, Ordering::SeqCst);
+        self.payload_bytes
+            .fetch_add(payload_bytes, Ordering::SeqCst);
+        self.packets.fetch_add(packets, Ordering::SeqCst);
+
+        if let Ok(duration) = now.duration_since(SystemTime::UNIX_EPOCH) {
+            let millis = duration.as_millis();
+            // NB: We truncate 128bits to 64 bits here, but even at 64 bits we have ~500k years
+            // before this becomes a problem, then it can be someone else's problem.
+            self.last_packet_timestamp
+                .store(millis as u64, Ordering::SeqCst);
+        } else {
+            log::warn!("SystemTime::now was before SystemTime::UNIX_EPOCH");
+        }
+    }
+
+    pub fn reader(&self) -> RTPStatsReader {
+        RTPStatsReader {
+            packets: self.packets.clone(),
+            payload_bytes: self.payload_bytes.clone(),
+            header_bytes: self.header_bytes.clone(),
+            last_packet_timestamp: self.last_packet_timestamp.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+/// Reader half of RTPStats.
+pub struct RTPStatsReader {
+    packets: Arc<AtomicU64>,
+    payload_bytes: Arc<AtomicU64>,
+    header_bytes: Arc<AtomicU64>,
+
+    last_packet_timestamp: Arc<AtomicU64>,
+}
+
+impl RTPStatsReader {
+    /// Get packets sent or received.
+    pub fn packets(&self) -> u64 {
+        self.packets.load(Ordering::SeqCst)
+    }
+
+    /// Get payload bytes sent or received.
+    pub fn header_bytes(&self) -> u64 {
+        self.header_bytes.load(Ordering::SeqCst)
+    }
+
+    /// Get header bytes sent or received.
+    pub fn payload_bytes(&self) -> u64 {
+        self.payload_bytes.load(Ordering::SeqCst)
+    }
+
+    pub fn last_packet_timestamp(&self) -> SystemTime {
+        let millis = self.last_packet_timestamp.load(Ordering::SeqCst);
+
+        SystemTime::UNIX_EPOCH + Duration::from_millis(millis)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rtp_stats() {
+        let stats: RTPStats = Default::default();
+        let reader = stats.reader();
+        assert_eq!(
+            (
+                reader.header_bytes(),
+                reader.payload_bytes(),
+                reader.packets()
+            ),
+            (0, 0, 0),
+        );
+
+        stats.update(24, 960, 1);
+
+        assert_eq!(
+            (
+                reader.header_bytes(),
+                reader.payload_bytes(),
+                reader.packets()
+            ),
+            (24, 960, 1),
+        );
+    }
+
+    #[test]
+    fn test_rtp_stats_send_sync() {
+        fn test_send_sync<T: Send + Sync>() {}
+        test_send_sync::<RTPStats>();
+    }
+}


### PR DESCRIPTION
Adds two interceptors with the purpose of collecting per RTP stream stats to start implementing the `"inbound-rtp"` and `"outbound-rtp"` categories of stats.

Outstanding question: How do we get ahold of the stats from the PC that the streams belong to? My best idea is a global `Lazy<Mutex<HashMap<SSRC, T>>`. Happy to hear thoughts
